### PR TITLE
Lock Sinatra to 2.0.3

### DIFF
--- a/lib/madman.rb
+++ b/lib/madman.rb
@@ -5,7 +5,6 @@ require 'sinatra/reloader'
 require 'slim'
 require 'string-direction'
 
-require 'madman/version'
 require 'madman/cli'
 require 'madman/injector'
 
@@ -17,7 +16,7 @@ require 'madman/navigation'
 
 require 'madman/server_base'
 require 'madman/preview_server'
-require 'madman/server'
+require 'madman/dir_server'
 
 
 require 'byebug' if ENV['BYEBUG']

--- a/lib/madman/commands/serve.rb
+++ b/lib/madman/commands/serve.rb
@@ -27,10 +27,10 @@ module Madman
 
         say "Starting server at !undblu!localhost:#{port}!txtrst! using the !txtgrn!#{renderer}!txtrst! renderer\n"
 
-        Madman::Server.set bind: bind, port: port, 
+        Madman::DirServer.set bind: bind, port: port, 
           dir: dir, renderer: renderer
           
-        Madman::Server.run!
+        Madman::DirServer.run!
       end
 
     end

--- a/lib/madman/dir_server.rb
+++ b/lib/madman/dir_server.rb
@@ -1,13 +1,9 @@
 module Madman
-  class Server < ServerBase
+  class DirServer < ServerBase
     set :public_folder, -> { File.expand_path(settings.dir) }
 
     before do
       @renderer = settings.respond_to?(:renderer) ? settings.renderer : :default
-    end
-
-    get '/favicon.ico' do
-      
     end
 
     get '/*' do

--- a/lib/madman/server_base.rb
+++ b/lib/madman/server_base.rb
@@ -8,5 +8,9 @@ module Madman
       register Sinatra::Reloader
       also_reload "#{__dir__}/*.rb"
     end
+
+    get '/favicon.ico' do
+    end
+
   end
 end

--- a/madman.gemspec
+++ b/madman.gemspec
@@ -17,10 +17,12 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = ">= 2.4.0"
 
+  # we are locking sinatra to 2.0.3 due to this issue:
+  # https://github.com/sinatra/sinatra/issues/1476
+  s.add_runtime_dependency 'sinatra', '2.0.3'
   s.add_runtime_dependency 'commonmarker', '~> 0.17'
   s.add_runtime_dependency 'mister_bin', '~> 0.3'
   s.add_runtime_dependency 'puma', '~> 3.11'
-  s.add_runtime_dependency 'sinatra', '~> 2.0'
   s.add_runtime_dependency 'sinatra-contrib', '~> 2.0'
   s.add_runtime_dependency 'slim', '~> 3.0'
   s.add_runtime_dependency 'string-direction', '~> 1.2'

--- a/spec/madman/commands/nav_spec.rb
+++ b/spec/madman/commands/nav_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'bin/madness-nav' do
+describe 'bin/madman nav' do
   subject { Madman::CLI.runner }
 
   context "without arguments" do

--- a/spec/madman/commands/preview_spec.rb
+++ b/spec/madman/commands/preview_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'bin/madness-preview' do
+describe 'bin/madman preview' do
   subject { Madman::CLI.runner }
 
   context "without arguments" do

--- a/spec/madman/commands/readme_spec.rb
+++ b/spec/madman/commands/readme_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'bin/madness-readme' do
+describe 'bin/madman readme' do
   subject { Madman::CLI.runner }
 
   context "without arguments" do

--- a/spec/madman/commands/render_spec.rb
+++ b/spec/madman/commands/render_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'bin/madness-render' do
+describe 'bin/madman render' do
   subject { Madman::CLI.runner }
 
   context "without arguments" do

--- a/spec/madman/commands/serve_spec.rb
+++ b/spec/madman/commands/serve_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'bin/madness-serve' do
+describe 'bin/madman serve' do
   subject { Madman::CLI.runner }
 
   context "without arguments" do
@@ -20,7 +20,7 @@ describe 'bin/madness-serve' do
     let(:argv) { %W[serve .] }
 
     it "calls the server" do
-      expect(Server).to receive(:run!)
+      expect(DirServer).to receive(:run!)
       expect{ subject.run argv }.to output(/Starting server/).to_stdout
     end
   end

--- a/spec/madman/dir_server_spec.rb
+++ b/spec/madman/dir_server_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Server do
+describe DirServer do
   before do 
-    Server.set dir: 'spec/workspace'
+    described_class.set dir: 'spec/workspace'
   end
 
   it "works" do


### PR DESCRIPTION
Sinatra 2.0.4 started issuing a warning related to ActiveSupport. Until this is removed, or we find the time to see how to bypass it, we are locking to 2.0.3.

Reference: https://github.com/sinatra/sinatra/issues/1476

---

Secondary objectives of this PR:

1. Rename `Server` to `DirServer`, since we might want to have `PreviewServer` be the actual main server, to perform editing commands as well as previewing.
2. Fix some spec typos