### PR TITLE
Add ability to render YAML into an interactive HTML

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,15 @@
 source "https://rubygems.org"
 
+gem 'byebug'
+gem 'lp'
+gem 'rack-test'
+gem 'rdoc'
+gem 'rspec'
+gem 'rspec-html-matchers'
+gem 'rspec_fixtures'
+gem 'runfile'
+gem 'runfile-tasks'
+gem 'simplecov'
+gem 'yard'
+
 gemspec

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Features
       compatibility.
 - [x] Automatic detection of Right-to-Left markdown files for HTML rendering.
 - [x] Generate navigation README in folders without one.
+- [x] Convert YAML file to an interactive HTML with collapsible sections.
 - [ ] Generate breadcrumbs.
 - [ ] Combine multiple markdown files to one.
 - [ ] Table of Contents generation for a single file.
@@ -56,15 +57,15 @@ Usage
 $ madman
 Commands:
   nav      Add site-wide navigation links to README files
-  preview  Serve a markdown file using a local server
+  preview  Serve a markdown or YAML file using a local server
   readme   Create README in all qualified sub directories
-  render   Render markdown to HTML
+  render   Render markdown or YAML to HTML
   serve    Serve a markdown directory using a local server
 ```
 
 <!-- usage -->
 
-### Render Markdown to File
+### Render Markdown or YAML to HTML
 
 <!-- render -->
 
@@ -82,7 +83,7 @@ Usage:
 
 ```
 $ madman render --help
-Render markdown to HTML
+Render markdown or YAML to HTML
 
 Usage:
   madman render FILE [--github --save OUTFILE]
@@ -101,7 +102,7 @@ Options:
 
 Parameters:
   FILE
-    The input markdown file
+    The input markdown or YAML file
 
 Environment Variables:
   GITHUB_ACCESS_TOKEN
@@ -112,12 +113,13 @@ Examples:
   madman render README.md
   madman render README.md --github
   madman render README.md --save out.html
+  madman render file.yml --save out.html
 ```
 
 <!-- render-help -->
 </details>
 
-### Preview Markdown in Browser
+### Preview Markdown or HTML in Browser
 
 <!-- preview -->
 
@@ -134,7 +136,7 @@ Usage:
 
 ```
 $ madman preview --help
-Serve a markdown file using a local server
+Serve a markdown or YAML file using a local server
 
 This command will start a local server with two endpoints:
   /         will render the markdown with the default renderer
@@ -156,7 +158,7 @@ Options:
 
 Parameters:
   FILE
-    The input markdown file
+    The input markdown or YAML file
 
 Environment Variables:
   GITHUB_ACCESS_TOKEN
@@ -167,6 +169,7 @@ Environment Variables:
 Examples:
   madman preview README.md
   madman preview README.md -p4000
+  madman preview file.yml
 ```
 
 <!-- preview-help --></details>

--- a/lib/madman.rb
+++ b/lib/madman.rb
@@ -1,5 +1,6 @@
 require 'byebug' if ENV['BYEBUG']
 require 'commonmarker'
+require 'mister_bin'
 require 'octokit'
 require 'requires'
 require 'sinatra/base'

--- a/lib/madman.rb
+++ b/lib/madman.rb
@@ -1,23 +1,11 @@
+require 'byebug' if ENV['BYEBUG']
 require 'commonmarker'
 require 'octokit'
+require 'requires'
 require 'sinatra/base'
 require 'sinatra/reloader'
 require 'slim'
 require 'string-direction'
+require 'yaml'
 
-require 'madman/version'
-require 'madman/cli'
-require 'madman/injector'
-
-require 'madman/directory'
-require 'madman/document'
-require 'madman/item'
-require 'madman/renderers'
-require 'madman/navigation'
-
-require 'madman/server_base'
-require 'madman/preview_server'
-require 'madman/dir_server'
-
-
-require 'byebug' if ENV['BYEBUG']
+requires 'madman'

--- a/lib/madman/cli.rb
+++ b/lib/madman/cli.rb
@@ -1,4 +1,3 @@
-require 'mister_bin'
 require 'madman/commands'
 
 module Madman

--- a/lib/madman/commands/preview.rb
+++ b/lib/madman/commands/preview.rb
@@ -3,7 +3,7 @@ module Madman
     class Preview < MisterBin::Command
       include Colsole
 
-      summary "Serve a markdown file using a local server"
+      summary "Serve a markdown or YAML file using a local server"
 
       help "This command will start a local server with two endpoints:\n  /         will render the markdown with the default renderer\n  /github   will render with the GitHub API"
 
@@ -13,7 +13,7 @@ module Madman
       option "-p --port N", "Set server port [default: 3000]"
       option "-b --bind ADDRESS", "Set server listen address [default: 0.0.0.0]"
 
-      param "FILE", "The input markdown file"
+      param "FILE", "The input markdown or YAML file"
 
       environment "GITHUB_ACCESS_TOKEN", "Your GitHub API access token\nRequired only if you wish to use the '/github' endpoint\nGenerate one here: https://github.com/settings/tokens"
 

--- a/lib/madman/commands/preview.rb
+++ b/lib/madman/commands/preview.rb
@@ -19,6 +19,7 @@ module Madman
 
       example "madman preview README.md"
       example "madman preview README.md -p4000"
+      example "madman preview file.yml"
 
       def run(args)
         file = args['FILE']

--- a/lib/madman/commands/render.rb
+++ b/lib/madman/commands/render.rb
@@ -18,6 +18,7 @@ module Madman
       example "madman render README.md"
       example "madman render README.md --github"
       example "madman render README.md --save out.html"
+      example "madman render file.yml --save out.html"
 
       def run(args)
         infile = args['FILE']

--- a/lib/madman/commands/render.rb
+++ b/lib/madman/commands/render.rb
@@ -3,7 +3,7 @@ module Madman
     class Render < MisterBin::Command
       include Colsole
 
-      help "Render markdown to HTML"
+      help "Render markdown or YAML to HTML"
 
       usage "madman render FILE [--github --save OUTFILE]"
       usage "madman render (-h|--help)"
@@ -11,7 +11,7 @@ module Madman
       option "--github", "Render using the GitHub API\nRequires setting the GITHUB_ACCESS_TOKEN environment variable"
       option "--save OUTFILE", "Save the output to a file"
 
-      param "FILE", "The input markdown file"
+      param "FILE", "The input markdown or YAML file"
 
       environment "GITHUB_ACCESS_TOKEN", "Your GitHub API access token\nGenerate one here: https://github.com/settings/tokens"
 

--- a/lib/madman/dir_server.rb
+++ b/lib/madman/dir_server.rb
@@ -1,3 +1,5 @@
+require 'madman/server_base'
+
 module Madman
   class DirServer < ServerBase
     set :public_folder, -> { File.expand_path(settings.dir) }
@@ -16,7 +18,7 @@ module Madman
       slim :template
     end
 
-    private
+  private
 
     def find_file(path)
       type = :file

--- a/lib/madman/directory.rb
+++ b/lib/madman/directory.rb
@@ -20,7 +20,7 @@ module Madman
       result
     end
 
-    private
+  private
 
     def files
       result = Dir["#{dir}/*.md"]

--- a/lib/madman/item.rb
+++ b/lib/madman/item.rb
@@ -22,7 +22,7 @@ module Madman
       type == :file
     end
 
-    private
+  private
 
     def path_without_extension
       @path_without_extension ||= path.sub(/\.md$/, '')

--- a/lib/madman/navigation.rb
+++ b/lib/madman/navigation.rb
@@ -1,3 +1,5 @@
+require 'madman/directory'
+
 module Madman
   # Generate a markdown Table of Contents
   class Navigation
@@ -15,7 +17,7 @@ module Madman
       @markdown ||= markdown!
     end
 
-    private
+  private
 
     def markdown!
       result = []

--- a/lib/madman/preview_server.rb
+++ b/lib/madman/preview_server.rb
@@ -1,3 +1,6 @@
+require 'madman/server_base'
+require 'madman/document'
+
 module Madman
   class PreviewServer < ServerBase
     set :public_folder, -> { File.expand_path(File.dirname(settings.file)) }

--- a/lib/madman/refinements/string.rb
+++ b/lib/madman/refinements/string.rb
@@ -1,0 +1,11 @@
+module StringRefinements
+  refine String do
+    def slug
+      downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
+    end
+
+    def to_html
+      CommonMarker.render_html self, :DEFAULT, [:table]
+    end
+  end
+end

--- a/lib/madman/renderers.rb
+++ b/lib/madman/renderers.rb
@@ -1,11 +1,13 @@
 require 'madman/renderers/default'
 require 'madman/renderers/github'
+require 'madman/renderers/yaml'
 
 module Madman
   module Renderers
     def self.available_renderers
       {
         default: Renderers::Default,
+        yaml: Renderers::YAML,
         github: Renderers::GitHub,
       }
     end

--- a/lib/madman/renderers/github.rb
+++ b/lib/madman/renderers/github.rb
@@ -5,7 +5,7 @@ module Madman
         client.markdown text
       end
 
-      private
+    private
 
       def self.client
         Octokit::Client.new access_token: access_token

--- a/lib/madman/renderers/yaml.rb
+++ b/lib/madman/renderers/yaml.rb
@@ -1,0 +1,12 @@
+module Madman
+  module Renderers
+    class YAML
+      def self.render(yaml, opts={})
+        doc = YAMLDoc.new yaml, title: opts[:title]
+        doc.render
+      end
+    end
+  end
+end
+
+

--- a/lib/madman/version.rb
+++ b/lib/madman/version.rb
@@ -1,3 +1,3 @@
 module Madman
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/lib/madman/yamldoc.rb
+++ b/lib/madman/yamldoc.rb
@@ -27,10 +27,6 @@ module Madman
       { pretty: true, disable_escape: true }
     end
 
-    def save(filename)
-      File.write filename, render
-    end
-
     def tree
       @tree ||= tree!
     end

--- a/lib/madman/yamldoc.rb
+++ b/lib/madman/yamldoc.rb
@@ -1,0 +1,80 @@
+require 'madman/refinements/string'
+
+module Madman
+  class YAMLDoc
+    using StringRefinements
+
+    attr_reader :yaml, :title
+
+    def initialize(yaml, title: nil)
+      @yaml = yaml
+      @title = title
+    end
+
+    def render
+      slim.render self
+    end
+
+    def template
+      File.expand_path '../views/yamldoc.slim', __dir__
+    end
+
+    def slim
+      @slim ||= Slim::Template.new template, slim_options
+    end
+
+    def slim_options
+      { pretty: true, disable_escape: true }
+    end
+
+    def save(filename)
+      File.write filename, render
+    end
+
+    def tree
+      @tree ||= tree!
+    end
+
+  private
+
+    def counter
+      @counter ||= 0
+      @counter += 1
+    end
+
+    def tree!(data=nil, indent=0, caption=2)
+      data ||= yaml
+      result = []
+      caption = 6 if caption > 6
+
+      data.each do |key, value|
+        result.push render_pair key, value, indent, caption
+      end
+
+      result.join "\n"
+    end
+
+    def render_pair(key, value, indent, caption)
+      slug = "#{key.slug}-#{counter}"
+      space = '  '
+      result = []
+
+      if key[0] == '_'
+        result.push "#{space * indent}<div>"
+      else
+        result.push "#{space * indent}<h#{caption}><a href='##{slug}' class='clickable'>#{key}</a></h#{caption}>"
+        result.push "#{space * indent}<div class='hidden' id='#{slug}'>"
+      end
+
+      if value.is_a? Hash
+        result.push tree!(value, indent+1, caption+1)
+      elsif value
+        result.push "#{space * (indent+1)}#{value.to_html}"
+      end
+
+      result.push "#{space * indent}</div>"
+      result
+    end
+
+  end
+end

--- a/lib/views/yamldoc.slim
+++ b/lib/views/yamldoc.slim
@@ -1,0 +1,52 @@
+doctype html
+html
+  head
+    meta name="viewport" content="width=device-width, initial-scale=1"
+    script src="https://code.jquery.com/jquery-3.3.1.min.js"integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="crossorigin="anonymous"
+    link href='https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/2.10.0/github-markdown.min.css' rel='stylesheet' type='text/css'
+
+  body
+
+    scss:
+      .markdown-body {
+        box-sizing: border-box;
+        min-width: 200px;
+        max-width: 980px;
+        margin: 0 auto;
+        padding: 45px;
+      }
+
+      @media (max-width: 767px) {
+        .markdown-body {
+          padding: 15px;
+        }
+      }
+
+      .s:hover {
+        cursor: pointer;
+      }
+
+      .hidden { 
+        display: none;
+        margin-left: 10px;
+      }
+
+
+    .markdown-body 
+      h1 
+        a#toggle-all href='#' = title
+
+      == tree
+
+
+    coffee:
+      $ ->
+        $('.clickable').on "click", (e) ->
+          e.preventDefault()
+          target = $(this).attr 'href'
+          $(target).toggle()
+
+        $('#toggle-all').on "click", (e) ->
+          e.preventDefault()
+          $('.hidden').toggle()
+

--- a/madman.gemspec
+++ b/madman.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   # we are locking sinatra to 2.0.3 due to this issue:
   # https://github.com/sinatra/sinatra/issues/1476
   s.add_runtime_dependency 'sinatra', '2.0.3'
+  s.add_runtime_dependency 'requires', '0.1'
   s.add_runtime_dependency 'commonmarker', '~> 0.17'
   s.add_runtime_dependency 'mister_bin', '~> 0.3'
   s.add_runtime_dependency 'puma', '~> 3.11'
@@ -27,16 +28,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'slim', '~> 3.0'
   s.add_runtime_dependency 'string-direction', '~> 1.2'
   s.add_runtime_dependency 'octokit', '~> 4.9'
-
-  s.add_development_dependency 'byebug', '~> 10.0'
-  s.add_development_dependency 'lp', '~> 0.0'
-  s.add_development_dependency 'rack-test', '~> 1.0'
-  s.add_development_dependency 'rdoc', '~> 6.0'
-  s.add_development_dependency 'rspec', '~> 3.6'
-  s.add_development_dependency 'rspec-html-matchers', '~> 0.9'
-  s.add_development_dependency 'rspec_fixtures', '~> 0.3'
-  s.add_development_dependency 'runfile', '~> 0.10'
-  s.add_development_dependency 'runfile-tasks', '~> 0.4'
-  s.add_development_dependency 'simplecov', '~> 0.15'
-  s.add_development_dependency 'yard', '~> 0.9'
+  s.add_runtime_dependency 'sass', "~> 3.6"
+  s.add_runtime_dependency 'coffee-script', '~> 2.4'
 end

--- a/spec/approvals/bin/commands
+++ b/spec/approvals/bin/commands
@@ -1,6 +1,6 @@
 Commands:
   [1;32mnav      [0mAdd site-wide navigation links to README files
-  [1;32mpreview  [0mServe a markdown file using a local server
+  [1;32mpreview  [0mServe a markdown or YAML file using a local server
   [1;32mreadme   [0mCreate README in all qualified sub directories
-  [1;32mrender   [0mRender markdown to HTML
+  [1;32mrender   [0mRender markdown or YAML to HTML
   [1;32mserve    [0mServe a markdown directory using a local server

--- a/spec/approvals/bin/preview/help
+++ b/spec/approvals/bin/preview/help
@@ -1,4 +1,4 @@
-Serve a markdown file using a local server
+Serve a markdown or YAML file using a local server
 
 This command will start a local server with two endpoints:
   /         will render the markdown with the default renderer
@@ -20,7 +20,7 @@ Options:
 
 Parameters:
   FILE
-    The input markdown file
+    The input markdown or YAML file
 
 Environment Variables:
   GITHUB_ACCESS_TOKEN

--- a/spec/approvals/bin/preview/help
+++ b/spec/approvals/bin/preview/help
@@ -31,3 +31,4 @@ Environment Variables:
 Examples:
   madman preview README.md
   madman preview README.md -p4000
+  madman preview file.yml

--- a/spec/approvals/bin/render/help
+++ b/spec/approvals/bin/render/help
@@ -28,3 +28,4 @@ Examples:
   madman render README.md
   madman render README.md --github
   madman render README.md --save out.html
+  madman render file.yml --save out.html

--- a/spec/approvals/bin/render/help
+++ b/spec/approvals/bin/render/help
@@ -1,4 +1,4 @@
-Render markdown to HTML
+Render markdown or YAML to HTML
 
 Usage:
   madman render FILE [--github --save OUTFILE]
@@ -17,7 +17,7 @@ Options:
 
 Parameters:
   FILE
-    The input markdown file
+    The input markdown or YAML file
 
 Environment Variables:
   GITHUB_ACCESS_TOKEN

--- a/spec/approvals/document/render_yaml
+++ b/spec/approvals/document/render_yaml
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content="width=device-width, initial-scale=1" name="viewport" />
+    <script crossorigin="anonymous" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/2.10.0/github-markdown.min.css" rel="stylesheet" type="text/css" />
+  </head>
+  <body>
+    <style type="text/css">
+      .markdown-body {
+        box-sizing: border-box;
+        min-width: 200px;
+        max-width: 980px;
+        margin: 0 auto;
+        padding: 45px;
+      }
+      
+      @media (max-width: 767px) {
+        .markdown-body {
+          padding: 15px;
+        }
+      }
+      .s:hover {
+        cursor: pointer;
+      }
+      
+      .hidden {
+        display: none;
+        margin-left: 10px;
+      }
+    </style>
+    <div class="markdown-body">
+      <h1>
+        <a href="#" id="toggle-all">hello</a>
+      </h1>
+      <div>
+        <p>Any key that begins with _ will only render its value</p>
+      
+      </div>
+      <h2><a href='#caption-2' class='clickable'>Caption</a></h2>
+      <div class='hidden' id='caption-2'>
+        <h3><a href='#subcaption-3' class='clickable'>SubCaption</a></h3>
+        <div class='hidden' id='subcaption-3'>
+          <p><strong>Some Markdown</strong></p>
+      <ul>
+      <li>Hello</li>
+      <li>World</li>
+      </ul>
+      
+        </div>
+      </div>
+    </div>
+    <script>
+      (function() {
+        $(function() {
+          $('.clickable').on("click", function(e) {
+            var target;
+            e.preventDefault();
+            target = $(this).attr('href');
+            return $(target).toggle();
+          });
+          return $('#toggle-all').on("click", function(e) {
+            e.preventDefault();
+            return $('.hidden').toggle();
+          });
+        });
+      
+      }).call(this);
+      
+    </script>
+  </body>
+</html>

--- a/spec/fixtures/hello.yml
+++ b/spec/fixtures/hello.yml
@@ -1,0 +1,8 @@
+_: Any key that begins with _ will only render its value
+
+Caption:
+  SubCaption: |
+    **Some Markdown**
+
+    - Hello
+    - World

--- a/spec/madman/commands/render_spec.rb
+++ b/spec/madman/commands/render_spec.rb
@@ -24,7 +24,7 @@ describe 'bin/madman render' do
     end
   end
 
-  context "with input file and --save", :focus do
+  context "with input file and --save" do
     let(:infile) { 'spec/fixtures/hello.md' }
     let(:outfile) { 'tmp/out.html' }
     let(:argv) { %W[render #{infile} --save #{outfile}] }

--- a/spec/madman/document_spec.rb
+++ b/spec/madman/document_spec.rb
@@ -16,11 +16,29 @@ describe Document do
     it "sets the instance filename" do
       expect(subject.filename).to eq filename
     end
+
+    context "with a yaml file" do
+      let(:filename) { 'spec/fixtures/hello.yml' }
+
+      it "loads the YAML hash into the instance text" do
+        expect(subject.text).to be_a Hash
+        expect(subject.text).to have_key "Caption"
+      end
+    end
   end
 
   describe '#render' do
     it 'returns HTML' do
       expect(subject.render).to match_fixture('document/render')
+    end
+
+    context "with a YAML file", :focus do
+      let(:filename) { 'spec/fixtures/hello.yml' }
+
+      it "also returns HTML" do
+        expect(subject.render).to match_fixture('document/render_yaml')
+      end
+      
     end
   end
 

--- a/spec/madman/document_spec.rb
+++ b/spec/madman/document_spec.rb
@@ -32,7 +32,7 @@ describe Document do
       expect(subject.render).to match_fixture('document/render')
     end
 
-    context "with a YAML file", :focus do
+    context "with a YAML file" do
       let(:filename) { 'spec/fixtures/hello.yml' }
 
       it "also returns HTML" do

--- a/spec/madman/refinements/string_spec.rb
+++ b/spec/madman/refinements/string_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe StringRefinements do
+  using StringRefinements
+
+  describe '#slug' do
+    it "converts a string to a slug" do
+      expect("Hello World".slug).to eq "hello-world"
+    end    
+  end
+
+  describe '#to_html' do
+    it "converts a string to a slug" do
+      expect("**Hello World**".to_html).to eq "<p><strong>Hello World</strong></p>\n"
+    end    
+  end
+end


### PR DESCRIPTION
This is a maintenance PR that includes a new YAML2HTML feature.

- [x] Move development dependencies from gemspec to Gemfile
- [x] Refactor dependency requirement, using the `requires` gem
- [x] The `render` and `preview` commands both support loading from YAML file, and generating an interactive, collapsible markdown


