### PR TITLE
Update sinatra to 2.0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,13 @@
 source "https://rubygems.org"
 
 gem 'byebug'
-gem 'github_changelog_generator'
 gem 'lp'
 gem 'rack-test'
-gem 'rdoc'
 gem 'rspec'
 gem 'rspec-html-matchers'
 gem 'rspec_fixtures'
 gem 'runfile'
 gem 'runfile-tasks'
 gem 'simplecov'
-gem 'yard'
 
 gemspec

--- a/Runfile
+++ b/Runfile
@@ -9,7 +9,6 @@ version Madman::VERSION
 
 RunfileTasks::RubyGems.all 'madman'
 RunfileTasks::Testing.rspec
-RunfileTasks::Docs.rdoc
 
 usage_commands = {
   'usage'        => 'madman',
@@ -24,11 +23,6 @@ usage_commands = {
   'readme'       => 'madman readme',
   'readme-help'  => 'madman readme --help',
 }
-
-help   "Run YARD server"
-action :yard do
-  run "yard server -p3000 -B0.0.0.0 -r"
-end
 
 help   "Run interactive console"
 action :console, :c do

--- a/madman.gemspec
+++ b/madman.gemspec
@@ -17,14 +17,12 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = ">= 2.4.0"
 
-  # we are locking sinatra to 2.0.3 due to this issue:
-  # https://github.com/sinatra/sinatra/issues/1476
-  s.add_runtime_dependency 'sinatra', '2.0.3'
+  s.add_runtime_dependency 'sinatra', '~> 2.0.5'
   s.add_runtime_dependency 'requires', '~> 0.1'
   s.add_runtime_dependency 'commonmarker', '~> 0.17'
   s.add_runtime_dependency 'mister_bin', '~> 0.6'
   s.add_runtime_dependency 'puma', '~> 3.11'
-  s.add_runtime_dependency 'sinatra-contrib', '~> 2.0'
+  s.add_runtime_dependency 'sinatra-contrib', '~> 2.0.5'
   s.add_runtime_dependency 'slim', '~> 4.0'
   s.add_runtime_dependency 'colsole', '~> 0.5'
   s.add_runtime_dependency 'string-direction', '~> 1.2'


### PR DESCRIPTION
Now that https://github.com/sinatra/sinatra/pull/1477 has been released, and the warning is gone - we can once again use the latest Sinatra.